### PR TITLE
Fix final PPM URL fetch

### DIFF
--- a/lib/preventive_maintenance_progress_page.dart
+++ b/lib/preventive_maintenance_progress_page.dart
@@ -116,7 +116,7 @@ class _PreventiveMaintenanceProgressPageState
     try {
       final schedTs = Timestamp.fromDate(widget.scheduledDate);
 
-      // 1) Try to find a progress doc for this date that contains a final URL
+      // Look for a progress doc for this date that contains a final URL
       final progSnap = await FirebaseFirestore.instance
           .collection('preventive_maintenance')
           .doc(widget.calendarId)
@@ -134,17 +134,7 @@ class _PreventiveMaintenanceProgressPageState
         }
       }
 
-      // 2) Fallback to the main document if nothing specific for this date
-      if (url == null) {
-        final pmDoc = await FirebaseFirestore.instance
-            .collection('preventive_maintenance')
-            .doc(widget.calendarId)
-            .get();
-        if (pmDoc.exists) {
-          final data = pmDoc.data() as Map<String, dynamic>? ?? {};
-          url = data['finalPpmReportUrl'] as String?;
-        }
-      }
+
 
       setState(() {
         _finalPpmReportUrl = url;


### PR DESCRIPTION
## Summary
- only load final PPM URL from progress docs

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842229a75788323bca95a821d7c5a58